### PR TITLE
bind handle methods in es6 

### DIFF
--- a/components/comment-box.js
+++ b/components/comment-box.js
@@ -8,6 +8,7 @@ import CommentForm from './comment-form'
 export default class CommentBox extends Component {
   constructor (props) {
     super(props)
+    this.handleCommentSubmit = this.handleCommentSubmit.bind(this)
     this.state = { data: [] }
   }
 

--- a/components/comment-form.js
+++ b/components/comment-form.js
@@ -3,6 +3,12 @@
 import React, { Component, PropTypes } from 'react'
 
 export default class CommentForm extends Component {
+
+  constructor(props) {
+    super(props);
+    this.handleSubmit = this.handleSubmit.bind(this)
+  }
+
   handleSubmit (e) {
     e.preventDefault()
     const author = this.refs.author.value.trim()


### PR DESCRIPTION
handle methods used in react are no longer bound automatically. therefore, we need to bind them in the constructor

refer to https://github.com/goatslacker/alt/issues/283
